### PR TITLE
[M3] Simple single-staff renderer + ScoreView (slurs, hairpins, hit-test)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,10 @@ let package = Package(
             dependencies: ["ScoreKit"],
             path: "Tests/ScoreKitTests"
         ),
+        .testTarget(
+            name: "ScoreKitUITests",
+            dependencies: ["ScoreKitUI"],
+            path: "Tests/ScoreKitUITests"
+        ),
     ]
 )
-

--- a/Sources/ScoreKitUI/Rendering/SimpleRenderer.swift
+++ b/Sources/ScoreKitUI/Rendering/SimpleRenderer.swift
@@ -1,0 +1,170 @@
+import Foundation
+import CoreGraphics
+import SwiftUI
+import ScoreKit
+
+public struct LayoutOptions: Sendable {
+    public var staffSpacing: CGFloat = 10 // distance between staff lines
+    public var noteSpacing: CGFloat = 24  // nominal horizontal advance per event
+    public var padding: CGSize = .init(width: 20, height: 20)
+    public init() {}
+}
+
+public struct LayoutElement: Sendable {
+    public enum Kind: Sendable { case note(Pitch), rest }
+    public let index: Int
+    public let kind: Kind
+    public let frame: CGRect
+}
+
+public struct LayoutSlur: Sendable { public let startIndex: Int; public let endIndex: Int }
+public struct LayoutHairpin: Sendable { public let startIndex: Int; public let endIndex: Int; public let crescendo: Bool }
+
+public struct LayoutTree: Sendable {
+    public let size: CGSize
+    public let elements: [LayoutElement]
+    public let slurs: [LayoutSlur]
+    public let hairpins: [LayoutHairpin]
+}
+
+public struct ScoreHit: Sendable { public let index: Int }
+
+public protocol ScoreRenderable {
+    func layout(events: [NotatedEvent], in rect: CGRect, options: LayoutOptions) -> LayoutTree
+    func draw(_ tree: LayoutTree, in ctx: CGContext, options: LayoutOptions)
+    func hitTest(_ tree: LayoutTree, at point: CGPoint) -> ScoreHit?
+}
+
+public struct SimpleRenderer: ScoreRenderable {
+    public init() {}
+
+    public func layout(events: [NotatedEvent], in rect: CGRect, options: LayoutOptions) -> LayoutTree {
+        let staffHeight = options.staffSpacing * 4 // 5 lines = 4 gaps
+        let width = options.padding.width * 2 + CGFloat(events.count) * options.noteSpacing
+        let height = options.padding.height * 2 + staffHeight + 40 // extra for hairpins/ledger
+        var elements: [LayoutElement] = []
+        var slurs: [LayoutSlur] = []
+        var hairpins: [LayoutHairpin] = []
+        let origin = CGPoint(x: options.padding.width, y: options.padding.height)
+
+        for (i, e) in events.enumerated() {
+            let x = origin.x + CGFloat(i) * options.noteSpacing
+            let y: CGFloat
+            let frame: CGRect
+            switch e.base {
+            case let .note(p, _):
+                y = trebleYOffset(for: p, staffSpacing: options.staffSpacing, originY: origin.y)
+                frame = CGRect(x: x - 5, y: y - 5, width: 10, height: 10)
+                elements.append(LayoutElement(index: i, kind: .note(p), frame: frame))
+            case .rest:
+                y = origin.y + staffHeight/2 - 3
+                frame = CGRect(x: x - 4, y: y - 4, width: 8, height: 8)
+                elements.append(LayoutElement(index: i, kind: .rest, frame: frame))
+            }
+            if e.slurStart {
+                if let end = events[(i+1)...].firstIndex(where: { $0.slurEnd }) {
+                    slurs.append(LayoutSlur(startIndex: i, endIndex: end))
+                }
+            }
+            if let hp = e.hairpinStart {
+                if let end = events[(i+1)...].firstIndex(where: { $0.hairpinEnd }) {
+                    hairpins.append(LayoutHairpin(startIndex: i, endIndex: end, crescendo: hp == .crescendo))
+                }
+            }
+        }
+        return LayoutTree(size: CGSize(width: max(rect.width, width), height: max(rect.height, height)), elements: elements, slurs: slurs, hairpins: hairpins)
+    }
+
+    public func draw(_ tree: LayoutTree, in ctx: CGContext, options: LayoutOptions) {
+        ctx.saveGState()
+        defer { ctx.restoreGState() }
+        // Draw staff (treble) baseline at padding origin
+        let origin = CGPoint(x: options.padding.width, y: options.padding.height)
+        ctx.setStrokeColor(CGColor(gray: 0.0, alpha: 1.0))
+        ctx.setLineWidth(1)
+        for i in 0..<5 {
+            let y = origin.y + CGFloat(i) * options.staffSpacing
+            ctx.move(to: CGPoint(x: origin.x, y: y))
+            ctx.addLine(to: CGPoint(x: tree.size.width - options.padding.width, y: y))
+        }
+        ctx.strokePath()
+
+        // Draw notes/rests
+        for el in tree.elements {
+            switch el.kind {
+            case .note:
+                ctx.setFillColor(CGColor(gray: 0.0, alpha: 1.0))
+                ctx.fillEllipse(in: el.frame)
+            case .rest:
+                ctx.setFillColor(CGColor(gray: 0.5, alpha: 1.0))
+                ctx.fill(el.frame)
+            }
+        }
+
+        // Draw slurs (simple bezier above notes)
+        for s in tree.slurs {
+            guard s.startIndex < tree.elements.count, s.endIndex < tree.elements.count else { continue }
+            let a = tree.elements[s.startIndex].frame
+            let b = tree.elements[s.endIndex].frame
+            let start = CGPoint(x: a.midXVal, y: a.minY - 6)
+            let end = CGPoint(x: b.midXVal, y: b.minY - 6)
+            let ctrl = CGPoint(x: (start.x + end.x)/2, y: min(start.y, end.y) - 12)
+            ctx.setStrokeColor(CGColor(gray: 0.0, alpha: 1.0))
+            ctx.setLineWidth(1)
+            ctx.move(to: start)
+            ctx.addQuadCurve(to: end, control: ctrl)
+            ctx.strokePath()
+        }
+
+        // Draw hairpins below staff
+        for h in tree.hairpins {
+            guard h.startIndex < tree.elements.count, h.endIndex < tree.elements.count else { continue }
+            let a = tree.elements[h.startIndex].frame
+            let b = tree.elements[h.endIndex].frame
+            let baseline = max(a.maxY, b.maxY) + 18
+            let start = CGPoint(x: a.midXVal, y: baseline)
+            let end = CGPoint(x: b.midXVal, y: baseline)
+            ctx.setStrokeColor(CGColor(gray: 0.0, alpha: 1.0))
+            ctx.setLineWidth(1)
+            if h.crescendo {
+                // opening wedge
+                ctx.move(to: start)
+                ctx.addLine(to: CGPoint(x: end.x, y: end.y - 6))
+                ctx.move(to: start)
+                ctx.addLine(to: CGPoint(x: end.x, y: end.y + 6))
+            } else {
+                // closing wedge
+                ctx.move(to: end)
+                ctx.addLine(to: CGPoint(x: start.x, y: start.y - 6))
+                ctx.move(to: end)
+                ctx.addLine(to: CGPoint(x: start.x, y: start.y + 6))
+            }
+            ctx.strokePath()
+        }
+    }
+
+    public func hitTest(_ tree: LayoutTree, at point: CGPoint) -> ScoreHit? {
+        if let el = tree.elements.first(where: { $0.frame.insetBy(dx: -4, dy: -4).contains(point) }) {
+            return ScoreHit(index: el.index)
+        }
+        return nil
+    }
+
+    // MARK: - Helpers
+    // Very rough treble clef mapping: E4 on bottom line; middle C (C4) one ledger below.
+    private func trebleYOffset(for p: Pitch, staffSpacing: CGFloat, originY: CGFloat) -> CGFloat {
+        // Map semitone distance from C4 in diatonic steps for staff position approximation.
+        let stepIndex: Int
+        switch p.step { case .C: stepIndex = 0; case .D: stepIndex = 1; case .E: stepIndex = 2; case .F: stepIndex = 3; case .G: stepIndex = 4; case .A: stepIndex = 5; case .B: stepIndex = 6 }
+        let diatonic = (p.octave - 4) * 7 + stepIndex // C4 = 0
+        // Each diatonic step = half a staff space (line/space). ledger below grows negative.
+        let c4Y = originY + staffSpacing * 5 // place C4 below staff by two spaces
+        let offset = -CGFloat(diatonic) * (staffSpacing / 2)
+        return c4Y + offset
+    }
+}
+
+extension CGRect {
+    var midXVal: CGFloat { origin.x + size.width/2 }
+    var midYVal: CGFloat { origin.y + size.height/2 }
+}

--- a/Sources/ScoreKitUI/Views/ScoreView.swift
+++ b/Sources/ScoreKitUI/Views/ScoreView.swift
@@ -1,17 +1,41 @@
 import SwiftUI
+import ScoreKit
 
 public struct ScoreView: View {
-    public init() {}
+    private let events: [NotatedEvent]
+    private let renderer = SimpleRenderer()
+    private let options = LayoutOptions()
+
+    public init(events: [NotatedEvent]) {
+        self.events = events
+    }
+
     public var body: some View {
-        Text("ScoreKit ScoreView")
-            .font(.headline)
-            .padding()
+        GeometryReader { proxy in
+            Canvas { ctx, size in
+                let rect = CGRect(origin: .zero, size: size)
+                let tree = renderer.layout(events: events, in: rect, options: options)
+                ctx.withCGContext { cg in
+                    renderer.draw(tree, in: cg, options: options)
+                }
+            }
+        }
+        .frame(minHeight: 160)
+        .background(Color(NSColor.textBackgroundColor))
+        .padding()
     }
 }
 
 #if DEBUG
 struct ScoreView_Previews: PreviewProvider {
-    static var previews: some View { ScoreView() }
+    static var previews: some View {
+        let base: [NotatedEvent] = [
+            .init(base: .note(pitch: Pitch(step: .C, alter: 0, octave: 4), duration: Duration(1,4)), hairpinStart: .crescendo),
+            .init(base: .note(pitch: Pitch(step: .D, alter: 0, octave: 4), duration: Duration(1,4)), slurStart: true),
+            .init(base: .note(pitch: Pitch(step: .E, alter: 0, octave: 4), duration: Duration(1,4)), slurEnd: true, hairpinEnd: true),
+            .init(base: .rest(duration: Duration(1,4)))
+        ]
+        return ScoreView(events: base)
+    }
 }
 #endif
-

--- a/Tests/ScoreKitUITests/RendererLayoutTests.swift
+++ b/Tests/ScoreKitUITests/RendererLayoutTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import ScoreKitUI
+import ScoreKit
+
+final class RendererLayoutTests: XCTestCase {
+    func testLayoutPositionsAndHitTest() {
+        let events: [NotatedEvent] = [
+            .init(base: .note(pitch: Pitch(step: .C, alter: 0, octave: 4), duration: Duration(1, 4))),
+            .init(base: .note(pitch: Pitch(step: .E, alter: 0, octave: 4), duration: Duration(1, 4)), slurStart: true),
+            .init(base: .note(pitch: Pitch(step: .G, alter: 0, octave: 4), duration: Duration(1, 4)), slurEnd: true),
+            .init(base: .rest(duration: Duration(1, 4)))
+        ]
+        let r = SimpleRenderer()
+        let tree = r.layout(events: events, in: CGRect(x: 0, y: 0, width: 400, height: 200), options: LayoutOptions())
+        XCTAssertEqual(tree.elements.count, 4)
+        // ascending x positions
+        XCTAssertLessThan(tree.elements[0].frame.minX, tree.elements[1].frame.minX)
+        XCTAssertLessThan(tree.elements[1].frame.minX, tree.elements[2].frame.minX)
+        // hit test near first note
+        let p = CGPoint(x: tree.elements[0].frame.midX, y: tree.elements[0].frame.midY)
+        let hit = r.hitTest(tree, at: p)
+        XCTAssertEqual(hit?.index, 0)
+        // slur captured
+        XCTAssertEqual(tree.slurs.count, 1)
+        XCTAssertEqual(tree.slurs[0].startIndex, 1)
+        XCTAssertEqual(tree.slurs[0].endIndex, 2)
+    }
+}
+


### PR DESCRIPTION
Delivers M3 MVP renderer:\n\n- SimpleRenderer: layouts single-staff notes/rests with rough treble mapping\n- Draws staff, noteheads, rests, slurs (quadratic), and hairpins (wedge)\n- Hit-testing returns event index\n- ScoreView: SwiftUI Canvas wrapper rendering given NotatedEvents\n- UI tests verify layout ordering, slur capture, hit-test\n\nNext: stems/flags, dynamics glyphs, selection visuals, and measure awareness.