### PR TITLE
[M3] Renderer: stems/flags, barlines + ScoreView selection; dynamics emission

### DIFF
--- a/Sources/ScoreKit/Engraving/LilyEmitter.swift
+++ b/Sources/ScoreKit/Engraving/LilyEmitter.swift
@@ -30,7 +30,9 @@ public enum LilyEmitter {
         for (i, e) in events.enumerated() {
             switch e.base {
             case let .note(pitch, dur):
-                var token = "\(lp(pitch))\(ld(dur))"
+                var prefix = ""
+                if let dyn = e.dynamic { prefix = "\\\(dyn.rawValue) " }
+                var token = prefix + "\(lp(pitch))\(ld(dur))"
                 for art in e.articulations { token += articulationSuffix(art) }
                 if e.slurStart { token += "(" }
                 if e.slurEnd { token += ")" }
@@ -38,7 +40,9 @@ public enum LilyEmitter {
                 if e.hairpinEnd { token += " \\!" }
                 lines.append(token)
             case let .rest(dur):
-                var token = "r\(ld(dur))"
+                var prefix = ""
+                if let dyn = e.dynamic { prefix = "\\\(dyn.rawValue) " }
+                var token = prefix + "r\(ld(dur))"
                 if e.slurStart { token += "(" }
                 if e.slurEnd { token += ")" }
                 if let hp = e.hairpinStart { token += hairpinStart(hp) }

--- a/Sources/ScoreKit/Model/Notation.swift
+++ b/Sources/ScoreKit/Model/Notation.swift
@@ -1,13 +1,17 @@
 import Foundation
 
-public enum Articulation: Codable, Sendable {
+public enum Articulation: Codable, Sendable, Equatable {
     case staccato
     case accent
 }
 
-public enum Hairpin: Codable, Sendable {
+public enum Hairpin: Codable, Sendable, Equatable {
     case crescendo
     case decrescendo
+}
+
+public enum DynamicLevel: String, Codable, Sendable, Equatable {
+    case p, f, mp, mf, pp, ff
 }
 
 public struct NotatedEvent: Codable, Sendable {
@@ -17,19 +21,22 @@ public struct NotatedEvent: Codable, Sendable {
     public var articulations: [Articulation]
     public var hairpinStart: Hairpin?
     public var hairpinEnd: Bool
+    public var dynamic: DynamicLevel?
 
     public init(base: Event,
                 slurStart: Bool = false,
                 slurEnd: Bool = false,
                 articulations: [Articulation] = [],
                 hairpinStart: Hairpin? = nil,
-                hairpinEnd: Bool = false) {
+                hairpinEnd: Bool = false,
+                dynamic: DynamicLevel? = nil) {
         self.base = base
         self.slurStart = slurStart
         self.slurEnd = slurEnd
         self.articulations = articulations
         self.hairpinStart = hairpinStart
         self.hairpinEnd = hairpinEnd
+        self.dynamic = dynamic
     }
 }
 
@@ -42,6 +49,7 @@ public enum PatchOp: Codable, Sendable {
     case slur(start: Int, end: Int)
     case hairpin(start: Int, end: Int, type: Hairpin)
     case articulation(index: Int, articulation: Articulation)
+    case dynamic(index: Int, level: DynamicLevel)
 }
 
 public enum Transform {
@@ -69,6 +77,13 @@ public enum Transform {
         }
         return (v, [.articulation(index: index, articulation: articulation)])
     }
+
+    public static func setDynamic(to voice: Voice, index: Int, level: DynamicLevel) -> (Voice, [PatchOp]) {
+        var v = voice
+        guard index >= 0, index < v.events.count else { return (v, []) }
+        v.events[index].dynamic = level
+        return (v, [.dynamic(index: index, level: level)])
+    }
 }
 
 private extension Articulation {
@@ -79,4 +94,3 @@ private extension Articulation {
         }
     }
 }
-

--- a/Sources/ScoreKitUI/Views/ScoreView.swift
+++ b/Sources/ScoreKitUI/Views/ScoreView.swift
@@ -3,25 +3,48 @@ import ScoreKit
 
 public struct ScoreView: View {
     private let events: [NotatedEvent]
+    private let barIndices: [Int]
     private let renderer = SimpleRenderer()
-    private let options = LayoutOptions()
+    private let onSelect: ((Int?) -> Void)?
+    @State private var selected: Int? = nil
 
-    public init(events: [NotatedEvent]) {
+    public init(events: [NotatedEvent], barIndices: [Int] = [], onSelect: ((Int?) -> Void)? = nil) {
         self.events = events
+        self.barIndices = barIndices
+        self.onSelect = onSelect
     }
 
     public var body: some View {
         GeometryReader { proxy in
             Canvas { ctx, size in
+                var opts = LayoutOptions()
+                opts.barIndices = barIndices
                 let rect = CGRect(origin: .zero, size: size)
-                let tree = renderer.layout(events: events, in: rect, options: options)
+                let tree = renderer.layout(events: events, in: rect, options: opts)
                 ctx.withCGContext { cg in
-                    renderer.draw(tree, in: cg, options: options)
+                    renderer.draw(tree, in: cg, options: opts)
+                    // Selection highlight
+                    if let sel = selected, sel >= 0, sel < tree.elements.count {
+                        let frame = tree.elements[sel].frame.insetBy(dx: -4, dy: -4)
+                        cg.setStrokeColor(CGColor(red: 0.2, green: 0.5, blue: 1.0, alpha: 1.0))
+                        cg.setLineWidth(2)
+                        cg.stroke(frame)
+                    }
                 }
             }
+            .contentShape(Rectangle())
+            .gesture(DragGesture(minimumDistance: 0).onEnded { value in
+                var opts = LayoutOptions()
+                opts.barIndices = barIndices
+                let rect = CGRect(origin: .zero, size: proxy.size)
+                let tree = renderer.layout(events: events, in: rect, options: opts)
+                let hit = renderer.hitTest(tree, at: value.location)
+                selected = hit?.index
+                onSelect?(selected)
+            })
         }
         .frame(minHeight: 160)
-        .background(Color(NSColor.textBackgroundColor))
+        .background(Color(nsColor: .textBackgroundColor))
         .padding()
     }
 }
@@ -35,7 +58,7 @@ struct ScoreView_Previews: PreviewProvider {
             .init(base: .note(pitch: Pitch(step: .E, alter: 0, octave: 4), duration: Duration(1,4)), slurEnd: true, hairpinEnd: true),
             .init(base: .rest(duration: Duration(1,4)))
         ]
-        return ScoreView(events: base)
+        return ScoreView(events: base, barIndices: [2])
     }
 }
 #endif

--- a/Tests/ScoreKitTests/ModelTransformTests.swift
+++ b/Tests/ScoreKitTests/ModelTransformTests.swift
@@ -40,4 +40,14 @@ final class ModelTransformTests: XCTestCase {
         print("ARTIC_LY=\n\(ly)")
         XCTAssertTrue(ly.contains("c'4-."))
     }
+
+    func testDynamicEmission() throws {
+        let base: [NotatedEvent] = [
+            .init(base: .note(pitch: Pitch(step: .C, alter: 0, octave: 4), duration: Duration(1, 4)))
+        ]
+        let voice = Voice(events: base)
+        let (v2, _) = Transform.setDynamic(to: voice, index: 0, level: .mf)
+        let ly = LilyEmitter.emit(notated: v2.events, title: "Dynamic Test")
+        XCTAssertTrue(ly.contains("\\mf c'4"))
+    }
 }

--- a/Tests/ScoreKitUITests/RendererLayoutTests.swift
+++ b/Tests/ScoreKitUITests/RendererLayoutTests.swift
@@ -11,19 +11,21 @@ final class RendererLayoutTests: XCTestCase {
             .init(base: .rest(duration: Duration(1, 4)))
         ]
         let r = SimpleRenderer()
-        let tree = r.layout(events: events, in: CGRect(x: 0, y: 0, width: 400, height: 200), options: LayoutOptions())
+        var opts = LayoutOptions(); opts.barIndices = [2]
+        let tree = r.layout(events: events, in: CGRect(x: 0, y: 0, width: 400, height: 200), options: opts)
         XCTAssertEqual(tree.elements.count, 4)
         // ascending x positions
         XCTAssertLessThan(tree.elements[0].frame.minX, tree.elements[1].frame.minX)
         XCTAssertLessThan(tree.elements[1].frame.minX, tree.elements[2].frame.minX)
         // hit test near first note
-        let p = CGPoint(x: tree.elements[0].frame.midX, y: tree.elements[0].frame.midY)
+        let p = CGPoint(x: tree.elements[0].frame.midXVal, y: tree.elements[0].frame.midYVal)
         let hit = r.hitTest(tree, at: p)
         XCTAssertEqual(hit?.index, 0)
         // slur captured
         XCTAssertEqual(tree.slurs.count, 1)
         XCTAssertEqual(tree.slurs[0].startIndex, 1)
         XCTAssertEqual(tree.slurs[0].endIndex, 2)
+        // barline captured at index 2
+        XCTAssertEqual(tree.barX.count, 1)
     }
 }
-


### PR DESCRIPTION
Adds to M3 MVP and interaction hooks:\n\n- Renderer: stems/flags for 8th+ durations, barlines via LayoutOptions.barIndices\n- ScoreView: interactive selection via gesture + onSelect callback, selection highlight\n- Model/Emitter: DynamicLevel + setDynamic transform and Lily emission (\p, \mf, etc.)\n- Tests: UI test updated (barlines), dynamic emission test added\n\nPreps for Teatro integration by exposing selection callbacks and highlight primitives.