### PR TITLE
[M3] Highlight API + Demo app

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     products: [
         .library(name: "ScoreKit", targets: ["ScoreKit"]),
         .library(name: "ScoreKitUI", targets: ["ScoreKitUI"]),
+        .executable(name: "ScoreKitDemo", targets: ["ScoreKitDemo"]),
     ],
     targets: [
         .target(
@@ -30,6 +31,11 @@ let package = Package(
             name: "ScoreKitUITests",
             dependencies: ["ScoreKitUI"],
             path: "Tests/ScoreKitUITests"
+        ),
+        .executableTarget(
+            name: "ScoreKitDemo",
+            dependencies: ["ScoreKitUI"],
+            path: "Sources/ScoreKitDemo"
         ),
     ]
 )

--- a/Sources/ScoreKitDemo/AppMain.swift
+++ b/Sources/ScoreKitDemo/AppMain.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import ScoreKit
+import ScoreKitUI
+
+@main
+struct ScoreKitDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            DemoView()
+        }
+    }
+}
+
+struct DemoView: View {
+    @State private var events: [NotatedEvent] = [
+        .init(base: .note(pitch: Pitch(step: .C, alter: 0, octave: 4), duration: Duration(1,8)), hairpinStart: .crescendo),
+        .init(base: .note(pitch: Pitch(step: .D, alter: 0, octave: 4), duration: Duration(1,8)), slurStart: true, articulations: [.staccato]),
+        .init(base: .note(pitch: Pitch(step: .E, alter: 0, octave: 4), duration: Duration(1,8)), slurEnd: true, hairpinEnd: true, dynamic: .mf),
+        .init(base: .rest(duration: Duration(1,4)))
+    ]
+    @State private var bars: [Int] = [3]
+    @StateObject private var highlighter = ScoreHighlighter()
+    @State private var selected: Int? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("ScoreKit Demo").font(.title2).padding(.top, 4)
+            ScoreView(events: events, barIndices: bars, highlighter: highlighter) { sel in
+                selected = sel
+            }
+            HStack {
+                Button("Flash bars 1–2") {
+                    let idx: Set<Int> = [0,1,2]
+                    highlighter.flash(indices: idx, duration: 0.8)
+                }
+                Button("Random flash") {
+                    let idx = Int.random(in: 0..<events.count)
+                    highlighter.flash(indices: [idx], duration: 0.6)
+                }
+                Button("Add staccato to sel") {
+                    if let i = selected {
+                        var v = Voice(events: events)
+                        let (nv, _) = Transform.addArticulation(to: v, index: i, articulation: .staccato)
+                        events = nv.events
+                    }
+                }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .frame(minWidth: 640, minHeight: 360)
+    }
+}
+

--- a/Sources/ScoreKitUI/Interaction/ScoreHighlighter.swift
+++ b/Sources/ScoreKitUI/Interaction/ScoreHighlighter.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Combine
+
+@MainActor
+public final class ScoreHighlighter: ObservableObject {
+    @Published public private(set) var indices: Set<Int> = []
+    @Published public private(set) var opacity: Double = 0.0
+    private var timer: Timer?
+
+    public init() {}
+
+    public func clear() {
+        timer?.invalidate(); timer = nil
+        indices = []
+        opacity = 0.0
+    }
+
+    public func flash(indices: Set<Int>, duration: TimeInterval = 0.8) {
+        guard !indices.isEmpty else { return }
+        self.indices = indices
+        self.opacity = 1.0
+        timer?.invalidate()
+        let steps = 20
+        let interval = duration / Double(steps)
+        var remaining = steps
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] t in
+            guard let self = self else { t.invalidate(); return }
+            remaining -= 1
+            let progress = 1.0 - (Double(remaining) / Double(steps))
+            Task { @MainActor in
+                self.opacity = max(0.0, 1.0 - progress)
+                if remaining <= 0 {
+                    t.invalidate()
+                    self.opacity = 0.0
+                    self.indices = []
+                }
+            }
+        }
+        RunLoop.main.add(timer!, forMode: .common)
+    }
+}


### PR DESCRIPTION
Adds highlighter and demo for Teatro-like interactions.\n\n- ScoreHighlighter: ObservableObject with flash(indices:duration:)\n- ScoreView: accepts highlighter, draws flash overlays, selection triggers flash\n- Demo: SwiftUI executable target ScoreKitDemo with buttons to flash and edit\n- CI unchanged; demo builds on macOS but not used in tests\n\nThis sets up simple highlight/animation hooks for UI flows.