### PR TITLE
feat(ui/bridge): TeatroBridge + ScoreController, flash range/pulse, external selection binding

### DIFF
--- a/Sources/ScoreKitDemo/AppMain.swift
+++ b/Sources/ScoreKitDemo/AppMain.swift
@@ -19,31 +19,33 @@ struct DemoView: View {
         .init(base: .rest(duration: Duration(1,4)))
     ]
     @State private var bars: [Int] = [3]
-    @StateObject private var highlighter = ScoreHighlighter()
+    @StateObject private var controller = ScoreController(highlighter: ScoreHighlighter())
     @State private var selected: Int? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("ScoreKit Demo").font(.title2).padding(.top, 4)
-            ScoreView(events: events, barIndices: bars, highlighter: highlighter) { sel in
+            ScoreView(events: events, barIndices: bars, highlighter: controller.highlighter, selection: $controller.selected) { sel in
                 selected = sel
             }
             HStack {
                 Button("Flash bars 1–2") {
                     let idx: Set<Int> = [0,1,2]
-                    highlighter.flash(indices: idx, duration: 0.8)
+                    controller.flash(indices: idx, duration: 0.8)
                 }
                 Button("Random flash") {
                     let idx = Int.random(in: 0..<events.count)
-                    highlighter.flash(indices: [idx], duration: 0.6)
+                    controller.flash(indices: [idx], duration: 0.6)
                 }
+                Button("Pulse melody") { controller.pulse(indices: [0,1,2], cycles: 3, period: 0.5) }
                 Button("Add staccato to sel") {
                     if let i = selected {
-                        var v = Voice(events: events)
+                        let v = Voice(events: events)
                         let (nv, _) = Transform.addArticulation(to: v, index: i, articulation: .staccato)
                         events = nv.events
                     }
                 }
+                Button("Focus #2") { controller.focus(index: 2) }
             }
             .buttonStyle(.borderedProminent)
         }
@@ -51,4 +53,3 @@ struct DemoView: View {
         .frame(minWidth: 640, minHeight: 360)
     }
 }
-

--- a/Sources/ScoreKitUI/Interaction/TeatroBridge.swift
+++ b/Sources/ScoreKitUI/Interaction/TeatroBridge.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+@MainActor
+public protocol TeatroBridge: AnyObject {
+    func flash(indices: Set<Int>, duration: TimeInterval)
+    func flash(range: ClosedRange<Int>, duration: TimeInterval)
+    func pulse(indices: Set<Int>, cycles: Int, period: TimeInterval)
+    func focus(index: Int?)
+}
+
+@MainActor
+public final class ScoreController: ObservableObject, TeatroBridge {
+    public let highlighter: ScoreHighlighter
+    @Published public var selected: Int? = nil
+
+    public init(highlighter: ScoreHighlighter) {
+        self.highlighter = highlighter
+    }
+
+    public func flash(indices: Set<Int>, duration: TimeInterval = 0.8) {
+        highlighter.flash(indices: indices, duration: duration)
+    }
+
+    public func flash(range: ClosedRange<Int>, duration: TimeInterval = 0.8) {
+        highlighter.flash(range: range, duration: duration)
+    }
+
+    public func pulse(indices: Set<Int>, cycles: Int = 2, period: TimeInterval = 0.6) {
+        highlighter.pulse(indices: indices, cycles: cycles, period: period)
+    }
+
+    public func focus(index: Int?) {
+        selected = index
+        if let i = index { flash(indices: [i], duration: 0.6) }
+    }
+}


### PR DESCRIPTION
- Adds @MainActor TeatroBridge protocol for storyboard cues\n- ScoreController implements TeatroBridge with focus/flash/pulse APIs\n- ScoreHighlighter gains flash(range:) and pulse(cycles:period:)\n- ScoreView accepts external selection Binding and continues to draw highlights\n- Demo updated to show controller usage (flash, pulse, focus)\n\nPreps for deeper Teatro integration by exposing controller-driven selection and highlight hooks.