### PR TITLE
feat(demo): Integrated storyboard player (cues for flash/pulse/focus)

### DIFF
--- a/Sources/ScoreKitDemo/AppMain.swift
+++ b/Sources/ScoreKitDemo/AppMain.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import ScoreKit
 import ScoreKitUI
+import Foundation
 
 @main
 struct ScoreKitDemoApp: App {
@@ -21,6 +22,8 @@ struct DemoView: View {
     @State private var bars: [Int] = [3]
     @StateObject private var controller = ScoreController(highlighter: ScoreHighlighter())
     @State private var selected: Int? = nil
+    @StateObject private var player = StoryboardPlayer()
+    @State private var cues: [Cue] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -46,10 +49,30 @@ struct DemoView: View {
                     }
                 }
                 Button("Focus #2") { controller.focus(index: 2) }
+                Button(player.isPlaying ? "Stop Storyboard" : "Play Storyboard") {
+                    if player.isPlaying { player.stop() }
+                    else { buildStoryboard(); player.play(cues: cues, controller: controller) }
+                }
             }
             .buttonStyle(.borderedProminent)
         }
         .padding()
         .frame(minWidth: 640, minHeight: 360)
+        .onAppear { buildStoryboard() }
+    }
+
+    private func buildStoryboard() {
+        // Simple scripted sequence demonstrating cues
+        var seq: [Cue] = []
+        seq.append(.init(at: 0.0, action: .focus(0)))
+        seq.append(.init(at: 0.2, action: .flashIndices([0,1,2], 0.9)))
+        seq.append(.init(at: 1.2, action: .pulse([0,1,2], 2, 0.45)))
+        seq.append(.init(at: 2.0, action: .focus(2)))
+        seq.append(.init(at: 2.2, action: .flashRange(0...3, 0.8)))
+        seq.append(.init(at: 3.0, action: .focus(nil)))
+        // random last highlight
+        let r = Int.random(in: 0..<events.count)
+        seq.append(.init(at: 3.4, action: .flashIndices([r], 0.6)))
+        cues = seq
     }
 }

--- a/Sources/ScoreKitDemo/Storyboard.swift
+++ b/Sources/ScoreKitDemo/Storyboard.swift
@@ -1,0 +1,55 @@
+import Foundation
+import ScoreKitUI
+
+public enum CueAction {
+    case flashIndices(Set<Int>, TimeInterval)
+    case flashRange(ClosedRange<Int>, TimeInterval)
+    case pulse(Set<Int>, Int, TimeInterval)
+    case focus(Int?)
+}
+
+public struct Cue {
+    public let at: TimeInterval
+    public let action: CueAction
+    public init(at: TimeInterval, action: CueAction) { self.at = at; self.action = action }
+}
+
+@MainActor
+public final class StoryboardPlayer: ObservableObject {
+    @Published public private(set) var isPlaying: Bool = false
+    private var work: [DispatchWorkItem] = []
+
+    public init() {}
+
+    public func play(cues: [Cue], controller: ScoreController) {
+        stop()
+        isPlaying = true
+        let start = DispatchTime.now()
+        for cue in cues {
+            let item = DispatchWorkItem { [weak controller] in
+                guard let controller = controller else { return }
+                switch cue.action {
+                case let .flashIndices(idx, dur): controller.flash(indices: idx, duration: dur)
+                case let .flashRange(range, dur): controller.flash(range: range, duration: dur)
+                case let .pulse(idx, cycles, period): controller.pulse(indices: idx, cycles: cycles, period: period)
+                case let .focus(i): controller.focus(index: i)
+                }
+            }
+            work.append(item)
+            DispatchQueue.main.asyncAfter(deadline: start + cue.at, execute: item)
+        }
+        // Mark complete at the last cue time + small epsilon
+        if let last = cues.map({ $0.at }).max() {
+            let done = DispatchWorkItem { [weak self] in self?.isPlaying = false }
+            work.append(done)
+            DispatchQueue.main.asyncAfter(deadline: start + last + 0.1, execute: done)
+        }
+    }
+
+    public func stop() {
+        for w in work { w.cancel() }
+        work.removeAll()
+        isPlaying = false
+    }
+}
+


### PR DESCRIPTION
- Adds StoryboardPlayer with timed cues (flash indices/range, pulse, focus)\n- Demo UI: Play/Stop Storyboard; builds a scripted sequence on appear\n- Uses ScoreController (TeatroBridge) to drive highlights and selection\n\nThis demonstrates integrated Teatro-style storyboard interactions in the demo app.