### PR TITLE
[M4] Semantics→Playback: schedule UMP + playhead

### DIFF
--- a/Sources/ScoreKit/Playback/PlaybackEngine.swift
+++ b/Sources/ScoreKit/Playback/PlaybackEngine.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+public struct Tempo: Sendable, Equatable {
+    public let bpm: Double // beats per minute, where beat = quarter note
+    public init(bpm: Double) { self.bpm = bpm }
+    public var secondsPerQuarter: Double { 60.0 / bpm }
+}
+
+public enum PlaybackError: Error { case empty }
+
+public final class PlaybackEngine: Sendable {
+    public init() {}
+
+    /// Schedule note on/off messages for a simple monophonic voice of notated events.
+    /// - Parameters:
+    ///   - events: notated events (notes/rests) with dynamics and hairpins
+    ///   - channel: MIDI channel (0..15)
+    ///   - tempo: tempo (quarter BPM)
+    ///   - startTime: start time offset in seconds (usually 0)
+    ///   - sink: receiver for scheduled UMP messages
+    public func schedule(events: [NotatedEvent], channel: UInt8 = 0, tempo: Tempo, startTime: TimeInterval = 0, sink: PlaybackSink) throws {
+        guard !events.isEmpty else { throw PlaybackError.empty }
+        // Precompute linear hairpin dynamic ramps across ranges
+        let dyns = effectiveDynamics(events: events)
+        var t = startTime
+        var scheduled: [ScheduledUMP] = []
+        for (i, e) in events.enumerated() {
+            switch e.base {
+            case let .note(p, d):
+                let key = midiFrom(pitch: p)
+                let vel = SemanticsMap.velocity(for: dyns[i])
+                scheduled.append(.init(time: t, message: .noteOn(channel: channel, key: key, velocity: vel)))
+                let durSec = seconds(for: d, tempo: tempo)
+                scheduled.append(.init(time: t + durSec, message: .noteOff(channel: channel, key: key, velocity: 0)))
+                t += durSec
+            case let .rest(d):
+                t += seconds(for: d, tempo: tempo)
+            }
+        }
+        sink.schedule(scheduled)
+    }
+
+    private func seconds(for d: Duration, tempo: Tempo) -> TimeInterval {
+        // Duration is num/den of whole note; quarter = 1/4.
+        let quarters = (Double(d.num) / Double(d.den)) * 4.0
+        return quarters * tempo.secondsPerQuarter
+    }
+
+    private func midiFrom(pitch: Pitch) -> UInt8 {
+        // Middle C (C4) = 60
+        let base: Int
+        switch pitch.step { case .C: base = 0; case .D: base = 2; case .E: base = 4; case .F: base = 5; case .G: base = 7; case .A: base = 9; case .B: base = 11 }
+        let semitone = (pitch.octave - 4) * 12 + base + pitch.alter
+        let note = 60 + semitone
+        return UInt8(max(0, min(127, note)))
+    }
+
+    private func effectiveDynamics(events: [NotatedEvent]) -> [DynamicLevel?] {
+        var result = events.map { $0.dynamic }
+        // Handle hairpins by distributing dynamics between explicit anchors
+        var i = 0
+        while i < events.count {
+            if let startDyn = events[i].dynamic ?? result[i], events[i].hairpinStart != nil {
+                if let endIdx = events[(i+1)...].firstIndex(where: { $0.hairpinEnd }) {
+                    let endDyn = events[endIdx].dynamic ?? startDyn
+                    // Compute ramp between i..endIdx inclusive
+                    let steps = max(1, endIdx - i)
+                    for k in 0...steps {
+                        let t = Double(k) / Double(steps)
+                        let from = SemanticsMap.velocity(for: startDyn)
+                        let to = SemanticsMap.velocity(for: endDyn)
+                        let lerp = UInt16(Double(from) * (1.0 - t) + Double(to) * t)
+                        // Map back to nearest dynamic approximation; keep as mf if unknown
+                        result[i + k] = nearestDynamic(to: lerp)
+                    }
+                    i = endIdx + 1
+                    continue
+                }
+            }
+            i += 1
+        }
+        return result
+    }
+
+    private func nearestDynamic(to velocity: UInt16) -> DynamicLevel {
+        // Heuristic map to the closest defined dynamic
+        let pairs: [(DynamicLevel, UInt16)] = [
+            (.pp, SemanticsMap.velocity(for: .pp)),
+            (.p, SemanticsMap.velocity(for: .p)),
+            (.mp, SemanticsMap.velocity(for: .mp)),
+            (.mf, SemanticsMap.velocity(for: .mf)),
+            (.f, SemanticsMap.velocity(for: .f)),
+            (.ff, SemanticsMap.velocity(for: .ff))
+        ]
+        return pairs.min(by: { abs(Int($0.1) - Int(velocity)) < abs(Int($1.1) - Int(velocity)) })!.0
+    }
+}
+

--- a/Sources/ScoreKit/Playback/SemanticsMap.swift
+++ b/Sources/ScoreKit/Playback/SemanticsMap.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public enum SemanticsMap {
+    public static func velocity(for dynamic: DynamicLevel?) -> UInt16 {
+        // Map to 16-bit velocity for MIDI 2.0 (0..65535)
+        let scale: Double
+        switch dynamic {
+        case .pp?: scale = 0.25
+        case .p?: scale = 0.40
+        case .mp?: scale = 0.55
+        case .mf?: scale = 0.70
+        case .f?: scale = 0.85
+        case .ff?: scale = 1.00
+        case nil: scale = 0.70
+        }
+        return UInt16((scale * 65535.0).rounded())
+    }
+}
+

--- a/Sources/ScoreKit/Playback/UMP.swift
+++ b/Sources/ScoreKit/Playback/UMP.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum UMPMessage: Sendable, Equatable {
+    case noteOn(channel: UInt8, key: UInt8, velocity: UInt16)
+    case noteOff(channel: UInt8, key: UInt8, velocity: UInt16)
+    case controlChange(channel: UInt8, controller: UInt8, value: UInt16)
+}
+
+public struct ScheduledUMP: Sendable, Equatable {
+    public let time: TimeInterval // seconds relative to start
+    public let message: UMPMessage
+}
+
+public protocol PlaybackSink: AnyObject {
+    func schedule(_ items: [ScheduledUMP])
+}
+
+public final class CollectingSink: PlaybackSink {
+    public private(set) var scheduled: [ScheduledUMP] = []
+    public init() {}
+    public func schedule(_ items: [ScheduledUMP]) { scheduled.append(contentsOf: items) }
+}
+

--- a/Sources/ScoreKitUI/Playback/Playhead.swift
+++ b/Sources/ScoreKitUI/Playback/Playhead.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Combine
+import ScoreKit
+
+@MainActor
+public final class Playhead: ObservableObject {
+    @Published public private(set) var index: Int = 0
+    @Published public private(set) var isPlaying: Bool = false
+    private var timer: Timer?
+
+    public init() {}
+
+    /// Drive the playhead visually over events using tempo and an optional callback.
+    public func start(events: [NotatedEvent], tempo: Tempo, tick: @escaping (Int) -> Void) {
+        stop()
+        guard !events.isEmpty else { return }
+        isPlaying = true; index = 0
+        let baseInterval = tempo.secondsPerQuarter
+        scheduleTick(events: events, base: baseInterval, tick: tick)
+    }
+
+    public func stop() {
+        timer?.invalidate(); timer = nil; isPlaying = false
+    }
+
+    private func scheduleTick(events: [NotatedEvent], base: TimeInterval, tick: @escaping (Int) -> Void) {
+        func durationSeconds(_ d: Duration) -> TimeInterval { (Double(d.num)/Double(d.den)) * 4.0 * base }
+        func nextInterval(at i: Int) -> TimeInterval {
+            guard i < events.count else { return 0 }
+            switch events[i].base {
+            case .note(_, let d): return durationSeconds(d)
+            case .rest(let d): return durationSeconds(d)
+            }
+        }
+        tick(index)
+        let interval = nextInterval(at: index)
+        timer = Timer.scheduledTimer(withTimeInterval: max(0.01, interval), repeats: true) { [weak self] t in
+            guard let self = self else { t.invalidate(); return }
+            Task { @MainActor in
+                self.index += 1
+                if self.index >= events.count { t.invalidate(); self.isPlaying = false; return }
+                tick(self.index)
+                t.invalidate()
+                self.scheduleTick(events: events, base: base, tick: tick)
+            }
+        }
+        if let tm = timer { RunLoop.main.add(tm, forMode: .common) }
+    }
+}

--- a/Tests/ScoreKitTests/PlaybackTests.swift
+++ b/Tests/ScoreKitTests/PlaybackTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import ScoreKit
+
+final class PlaybackTests: XCTestCase {
+    func testSchedulingTimesAndVelocities() throws {
+        let events: [NotatedEvent] = [
+            .init(base: .note(pitch: Pitch(step: .C, alter: 0, octave: 4), duration: Duration(1,4)), hairpinStart: .crescendo, dynamic: .p),
+            .init(base: .note(pitch: Pitch(step: .D, alter: 0, octave: 4), duration: Duration(1,4))),
+            .init(base: .note(pitch: Pitch(step: .E, alter: 0, octave: 4), duration: Duration(1,4)), hairpinEnd: true, dynamic: .f)
+        ]
+        let engine = PlaybackEngine()
+        let sink = CollectingSink()
+        try engine.schedule(events: events, channel: 0, tempo: Tempo(bpm: 120), startTime: 0, sink: sink)
+        // Expect 6 messages: on/off for each note
+        XCTAssertEqual(sink.scheduled.count, 6)
+        // Times: 0.0 on C, 0.5 off C, 0.5 on D, 1.0 off D, 1.0 on E, 1.5 off E
+        let times = sink.scheduled.map { $0.time }
+        XCTAssertEqual(times[0], 0.0, accuracy: 0.0001)
+        XCTAssertEqual(times[1], 0.5, accuracy: 0.0001)
+        XCTAssertEqual(times[2], 0.5, accuracy: 0.0001)
+        XCTAssertEqual(times[3], 1.0, accuracy: 0.0001)
+        XCTAssertEqual(times[4], 1.0, accuracy: 0.0001)
+        XCTAssertEqual(times[5], 1.5, accuracy: 0.0001)
+        // Velocities should ramp from p -> f
+        func vel(_ idx: Int) -> UInt16 {
+            if case let .noteOn(_, _, v) = sink.scheduled[idx].message { return v }; return 0
+        }
+        XCTAssertLessThan(vel(0), vel(2))
+        XCTAssertLessThan(vel(2), vel(4))
+    }
+}


### PR DESCRIPTION
Implements M4 basics:\n\n- PlaybackEngine: schedules note on/off UMP-like messages with JR-style timestamps (relative seconds), tempo-aware\n- SemanticsMap: maps DynamicLevel to MIDI 2.0 16-bit velocities; ramps hairpins\n- UMP model: UMPMessage + ScheduledUMP + PlaybackSink (CollectingSink for tests)\n- UI Playhead: drives visual position with tempo and durations\n- Tests: verify timings at 120 BPM and velocity ramp across hairpin\n\nThis provides a clean seam for a real UMP encoder/outgoing port later.