### PR TITLE
feat(playback/ui): CoreMIDI sender stub + beaming, range selection, UMP console send

### DIFF
--- a/Sources/ScoreKit/Playback/CoreMIDIPort.swift
+++ b/Sources/ScoreKit/Playback/CoreMIDIPort.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+#if canImport(CoreMIDI)
+import CoreMIDI
+
+public final class CoreMIDISender {
+    private var client = MIDIClientRef()
+    private var outPort = MIDIPortRef()
+    public init?(clientName: String = "ScoreKit", portName: String = "ScoreKit Out") {
+        var c = MIDIClientRef()
+        let s1 = MIDIClientCreateWithBlock(clientName as CFString, &c) { _ in }
+        guard s1 == noErr else { return nil }
+        var p = MIDIPortRef()
+        let s2 = MIDIOutputPortCreate(c, portName as CFString, &p)
+        guard s2 == noErr else { MIDIClientDispose(c); return nil }
+        self.client = c; self.outPort = p
+    }
+    deinit { MIDIPortDispose(outPort); MIDIClientDispose(client) }
+
+    public func destinationCount() -> Int { Int(MIDIGetNumberOfDestinations()) }
+    public func destinationName(at index: Int) -> String? {
+        let dest = MIDIGetDestination(index)
+        var prop: Unmanaged<CFString>?
+        if MIDIObjectGetStringProperty(dest, kMIDIPropertyName, &prop) == noErr {
+            return prop?.takeRetainedValue() as String?
+        }
+        return nil
+    }
+
+    public func sendUMP(words: [UInt32], to index: Int = 0) {
+        guard destinationCount() > 0 else { return }
+        let dest = MIDIGetDestination(index)
+        // Build a MIDIEventList for UMP (MIDI 2.0)
+        var storage = [UInt8](repeating: 0, count: 256)
+        storage.withUnsafeMutableBytes { raw in
+            let listPtr = raw.baseAddress!.assumingMemoryBound(to: MIDIEventList.self)
+            var packet = MIDIEventListInit(listPtr, ._2_0)
+            _ = words.withUnsafeBufferPointer { wbuf in
+                MIDIEventListAdd(listPtr, 256, packet, 0, wbuf.count, wbuf.baseAddress!)
+            }
+            MIDISendEventList(outPort, dest, listPtr)
+        }
+    }
+}
+
+#else
+public final class CoreMIDISender {
+    public init?(clientName: String = "ScoreKit", portName: String = "ScoreKit Out") { return nil }
+    public func destinationCount() -> Int { 0 }
+    public func destinationName(at index: Int) -> String? { nil }
+    public func sendUMP(words: [UInt32], to index: Int = 0) { /* no-op */ }
+}
+#endif

--- a/Sources/ScoreKit/Playback/UMPDump.swift
+++ b/Sources/ScoreKit/Playback/UMPDump.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum UMPDump {
+    public static func hexWords(_ words: [UInt32]) -> String {
+        words.map { String(format: "%08X", $0) }.joined(separator: " ")
+    }
+}
+

--- a/Sources/ScoreKitUI/Views/ScoreView.swift
+++ b/Sources/ScoreKitUI/Views/ScoreView.swift
@@ -7,14 +7,17 @@ public struct ScoreView: View {
     private let barIndices: [Int]
     private let renderer = SimpleRenderer()
     private let onSelect: ((Int?) -> Void)?
+    private let onSelectRange: ((Set<Int>) -> Void)?
     private let selectedBinding: Binding<Int?>?
     @ObservedObject private var highlighter: ScoreHighlighter
     @State private var selected: Int? = nil
+    @State private var dragRect: CGRect? = nil
 
-    public init(events: [NotatedEvent], barIndices: [Int] = [], highlighter: ScoreHighlighter? = nil, selection: Binding<Int?>? = nil, onSelect: ((Int?) -> Void)? = nil) {
+    public init(events: [NotatedEvent], barIndices: [Int] = [], highlighter: ScoreHighlighter? = nil, selection: Binding<Int?>? = nil, onSelect: ((Int?) -> Void)? = nil, onSelectRange: ((Set<Int>) -> Void)? = nil) {
         self.events = events
         self.barIndices = barIndices
         self.onSelect = onSelect
+        self.onSelectRange = onSelectRange
         self.selectedBinding = selection
         self._highlighter = ObservedObject(initialValue: highlighter ?? ScoreHighlighter())
     }
@@ -46,21 +49,42 @@ public struct ScoreView: View {
                             }
                         }
                     }
+                    // Drag selection overlay
+                    if let drag = dragRect {
+                        cg.setStrokeColor(CGColor(red: 0.0, green: 0.6, blue: 1.0, alpha: 0.8))
+                        cg.setLineWidth(1)
+                        cg.stroke(drag)
+                        cg.setFillColor(CGColor(red: 0.0, green: 0.6, blue: 1.0, alpha: 0.15))
+                        cg.fill(drag)
+                    }
                 }
             }
             .contentShape(Rectangle())
-            .gesture(DragGesture(minimumDistance: 0).onEnded { value in
-                var opts = LayoutOptions()
-                opts.barIndices = barIndices
-                let rect = CGRect(origin: .zero, size: proxy.size)
-                let tree = renderer.layout(events: events, in: rect, options: opts)
-                let hit = renderer.hitTest(tree, at: value.location)
-                let newSel = hit?.index
-                selected = newSel
-                selectedBinding?.wrappedValue = newSel
-                onSelect?(newSel)
-                if let idx = newSel { highlighter.flash(indices: [idx]) }
-            })
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let s = value.startLocation; let e = value.location
+                        dragRect = CGRect(x: min(s.x, e.x), y: min(s.y, e.y), width: abs(e.x - s.x), height: abs(e.y - s.y))
+                    }
+                    .onEnded { value in
+                        var opts = LayoutOptions(); opts.barIndices = barIndices
+                        let rect = CGRect(origin: .zero, size: proxy.size)
+                        let tree = renderer.layout(events: events, in: rect, options: opts)
+                        if let drag = dragRect, drag.width > 3 && drag.height > 3 {
+                            let set = Set(tree.elements.filter { $0.frame.intersects(drag) }.map { $0.index })
+                            onSelectRange?(set)
+                            if !set.isEmpty { highlighter.flash(indices: set) }
+                        } else {
+                            let hit = renderer.hitTest(tree, at: value.location)
+                            let newSel = hit?.index
+                            selected = newSel
+                            selectedBinding?.wrappedValue = newSel
+                            onSelect?(newSel)
+                            if let idx = newSel { highlighter.flash(indices: [idx]) }
+                        }
+                        dragRect = nil
+                    }
+            )
         }
         .frame(minHeight: 160)
         .background(Color(nsColor: .textBackgroundColor))


### PR DESCRIPTION
- CoreMIDISender (guarded by canImport(CoreMIDI)) with UMP send via MIDIEventList; safe no-op stub when not available\n- Renderer: variable spacing by duration, naive beaming for consecutive 8th+ notes\n- ScoreView: drag range selection overlay + onSelectRange callback\n- Demo: buttons to dump UMP to console and send to CoreMIDI dest 0 (best-effort)\n\nAll tests remain green; CoreMIDI code paths are not exercised in CI.