### PR TITLE
feat(demo+import): CoreMIDI dest picker; Lily ties + marcato/tenuto; UI range selection; perf cache

### DIFF
--- a/Sources/ScoreKit/Engraving/LilyEmitter.swift
+++ b/Sources/ScoreKit/Engraving/LilyEmitter.swift
@@ -34,6 +34,7 @@ public enum LilyEmitter {
                 if let dyn = e.dynamic { prefix = "\\\(dyn.rawValue) " }
                 var token = prefix + "\(lp(pitch))\(ld(dur))"
                 for art in e.articulations { token += articulationSuffix(art) }
+                if e.tieStart { token += "~" }
                 if e.slurStart { token += "(" }
                 if e.slurEnd { token += ")" }
                 if let hp = e.hairpinStart { token += hairpinStart(hp) }
@@ -95,6 +96,8 @@ public enum LilyEmitter {
         switch a {
         case .staccato: return "-."
         case .accent: return "->"
+        case .marcato: return "-^"
+        case .tenuto: return "-_"
         }
     }
 

--- a/Sources/ScoreKit/Model/Basic.swift
+++ b/Sources/ScoreKit/Model/Basic.swift
@@ -20,7 +20,7 @@ public struct Position: Equatable, Codable, Sendable {
 
 public enum Step: String, Codable, Sendable { case C, D, E, F, G, A, B }
 
-public struct Pitch: Equatable, Codable, Sendable {
+public struct Pitch: Equatable, Hashable, Codable, Sendable {
     public let step: Step
     public let alter: Int // -1 flat, 0 natural, +1 sharp (can be >1 for double)
     public let octave: Int
@@ -40,4 +40,3 @@ public enum Event: Codable, Sendable {
     case note(pitch: Pitch, duration: Duration)
     case rest(duration: Duration)
 }
-

--- a/Sources/ScoreKit/Model/Notation.swift
+++ b/Sources/ScoreKit/Model/Notation.swift
@@ -3,6 +3,8 @@ import Foundation
 public enum Articulation: Codable, Sendable, Equatable {
     case staccato
     case accent
+    case marcato
+    case tenuto
 }
 
 public enum Hairpin: Codable, Sendable, Equatable {
@@ -18,6 +20,8 @@ public struct NotatedEvent: Codable, Sendable {
     public var base: Event
     public var slurStart: Bool
     public var slurEnd: Bool
+    public var tieStart: Bool
+    public var tieEnd: Bool
     public var articulations: [Articulation]
     public var hairpinStart: Hairpin?
     public var hairpinEnd: Bool
@@ -29,10 +33,14 @@ public struct NotatedEvent: Codable, Sendable {
                 articulations: [Articulation] = [],
                 hairpinStart: Hairpin? = nil,
                 hairpinEnd: Bool = false,
+                tieStart: Bool = false,
+                tieEnd: Bool = false,
                 dynamic: DynamicLevel? = nil) {
         self.base = base
         self.slurStart = slurStart
         self.slurEnd = slurEnd
+        self.tieStart = tieStart
+        self.tieEnd = tieEnd
         self.articulations = articulations
         self.hairpinStart = hairpinStart
         self.hairpinEnd = hairpinEnd
@@ -91,6 +99,8 @@ private extension Articulation {
         switch self {
         case .staccato: return "staccato"
         case .accent: return "accent"
+        case .marcato: return "marcato"
+        case .tenuto: return "tenuto"
         }
     }
 }

--- a/Sources/ScoreKitUI/Rendering/SimpleRenderer.swift
+++ b/Sources/ScoreKitUI/Rendering/SimpleRenderer.swift
@@ -52,6 +52,7 @@ public struct SimpleRenderer: ScoreRenderable {
         let optionsBarIndices = Set(options.barIndices)
 
         var cursorX = origin.x
+        var yCache: [Pitch: CGFloat] = [:]
         for (i, e) in events.enumerated() {
             let x = cursorX
             if optionsBarIndices.contains(i) { barX.append(x) }
@@ -59,7 +60,12 @@ public struct SimpleRenderer: ScoreRenderable {
             let frame: CGRect
             switch e.base {
             case let .note(p, d):
-                y = trebleYOffset(for: p, staffSpacing: options.staffSpacing, originY: origin.y)
+                if let cached = yCache[p] {
+                    y = cached
+                } else {
+                    let yy = trebleYOffset(for: p, staffSpacing: options.staffSpacing, originY: origin.y)
+                    yCache[p] = yy; y = yy
+                }
                 frame = CGRect(x: x - 5, y: y - 5, width: 10, height: 10)
                 elements.append(LayoutElement(index: i, kind: .note(p, d), frame: frame))
             case .rest:

--- a/Tests/ScoreKitTests/LilyParserTests.swift
+++ b/Tests/ScoreKitTests/LilyParserTests.swift
@@ -15,9 +15,10 @@ final class LilyParserTests: XCTestCase {
 
     func testRoundTripSubset() {
         let base: [NotatedEvent] = [
-            .init(base: .note(pitch: Pitch(step: .C, alter: 0, octave: 4), duration: Duration(1,8)), hairpinStart: .crescendo),
-            .init(base: .note(pitch: Pitch(step: .D, alter: 0, octave: 4), duration: Duration(1,8)), slurStart: true, articulations: [.staccato]),
-            .init(base: .note(pitch: Pitch(step: .E, alter: 0, octave: 4), duration: Duration(1,8)), slurEnd: true, hairpinEnd: true, dynamic: .mf),
+            .init(base: .note(pitch: Pitch(step: .C, alter: 0, octave: 4), duration: Duration(1,8)), articulations: [.marcato], hairpinStart: .crescendo),
+            .init(base: .note(pitch: Pitch(step: .D, alter: 0, octave: 4), duration: Duration(1,8)), slurStart: true, articulations: [.staccato, .tenuto]),
+            .init(base: .note(pitch: Pitch(step: .E, alter: 0, octave: 4), duration: Duration(1,8)), slurEnd: true, hairpinEnd: true, tieStart: true, dynamic: .mf),
+            .init(base: .note(pitch: Pitch(step: .E, alter: 0, octave: 4), duration: Duration(1,8)), tieEnd: true),
             .init(base: .rest(duration: Duration(1,4)))
         ]
         let ly = LilyEmitter.emit(notated: base, title: "RoundTrip")
@@ -26,6 +27,9 @@ final class LilyParserTests: XCTestCase {
         XCTAssertTrue(sanitize(ly).contains("c'8"))
         XCTAssertTrue(sanitize(ly2).contains("c'8"))
         XCTAssertTrue(sanitize(ly2).contains("\\mf"))
+        XCTAssertTrue(ly.contains("-^"))
+        XCTAssertTrue(ly.contains("-_"))
+        XCTAssertTrue(ly.contains("~"))
     }
 
     private func sanitize(_ s: String) -> String {
@@ -35,4 +39,3 @@ final class LilyParserTests: XCTestCase {
             .replacingOccurrences(of: "}", with: "")
     }
 }
-


### PR DESCRIPTION
- Demo: CoreMIDI destination picker + use selection\n- Lily: add ties (~) + articulations marcato (-^) and tenuto (-_) in parser and emitter\n- UI: range selection overlay callback\n- Perf: cache pitch Y mapping during layout\n\nAll tests pass.