### PR TITLE
feat(renderer tests + bench): expose beam groups; add UI tests; add ScoreKitBench

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
         .library(name: "ScoreKit", targets: ["ScoreKit"]),
         .library(name: "ScoreKitUI", targets: ["ScoreKitUI"]),
         .executable(name: "ScoreKitDemo", targets: ["ScoreKitDemo"]),
+        .executable(name: "ScoreKitBench", targets: ["ScoreKitBench"]),
     ],
     targets: [
         .target(
@@ -36,6 +37,11 @@ let package = Package(
             name: "ScoreKitDemo",
             dependencies: ["ScoreKitUI"],
             path: "Sources/ScoreKitDemo"
+        ),
+        .executableTarget(
+            name: "ScoreKitBench",
+            dependencies: ["ScoreKitUI"],
+            path: "Sources/ScoreKitBench"
         ),
     ]
 )

--- a/Sources/ScoreKitBench/main.swift
+++ b/Sources/ScoreKitBench/main.swift
@@ -1,0 +1,37 @@
+import Foundation
+import ScoreKit
+import ScoreKitUI
+
+func time(_ label: String, _ block: () -> Void) {
+    let start = CFAbsoluteTimeGetCurrent()
+    block()
+    let dt = (CFAbsoluteTimeGetCurrent() - start) * 1000
+    print("\(label): \(String(format: "%.2f", dt)) ms")
+}
+
+func makeEvents(count: Int, den: Int) -> [NotatedEvent] {
+    var evs: [NotatedEvent] = []
+    let steps: [Step] = [.C,.D,.E,.F,.G,.A,.B]
+    for i in 0..<count {
+        let st = steps[i % steps.count]
+        evs.append(.init(base: .note(pitch: Pitch(step: st, alter: 0, octave: 4 + (i/steps.count)%2), duration: Duration(1, den))))
+    }
+    return evs
+}
+
+let renderer = SimpleRenderer()
+var opts = LayoutOptions(); opts.timeSignature = (4,4)
+let rect = CGRect(x: 0, y: 0, width: 1200, height: 300)
+
+let configs: [(String, [NotatedEvent])] = [
+    ("16 eighths", makeEvents(count: 16, den: 8)),
+    ("32 sixteenths", makeEvents(count: 32, den: 16)),
+    ("64 sixteenths", makeEvents(count: 64, den: 16)),
+]
+
+for (label, evs) in configs {
+    time("layout (\(label))") {
+        _ = renderer.layout(events: evs, in: rect, options: opts)
+    }
+}
+

--- a/Tests/ScoreKitUITests/BeamGroupingTests.swift
+++ b/Tests/ScoreKitUITests/BeamGroupingTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import ScoreKitUI
+import ScoreKit
+
+final class BeamGroupingTests: XCTestCase {
+    func testEighthsGroupWithinBeat() {
+        // 4/4: two eighths per beat => 4 eighths should form two groups [0,1], [2,3]
+        let events: [NotatedEvent] = [
+            .init(base: .note(pitch: Pitch(step: .C, alter: 0, octave: 4), duration: Duration(1,8))),
+            .init(base: .note(pitch: Pitch(step: .D, alter: 0, octave: 4), duration: Duration(1,8))),
+            .init(base: .note(pitch: Pitch(step: .E, alter: 0, octave: 4), duration: Duration(1,8))),
+            .init(base: .note(pitch: Pitch(step: .F, alter: 0, octave: 4), duration: Duration(1,8)))
+        ]
+        let r = SimpleRenderer()
+        var opts = LayoutOptions(); opts.timeSignature = (4,4)
+        let tree = r.layout(events: events, in: CGRect(x: 0, y: 0, width: 400, height: 160), options: opts)
+        XCTAssertEqual(tree.beamGroups.count, 2)
+        XCTAssertEqual(tree.beamGroups[0], [0,1])
+        XCTAssertEqual(tree.beamGroups[1], [2,3])
+    }
+
+    func testSixteenthBeamLevels() {
+        // 4/4: four 16ths in one beat should form one group with level >= 2
+        let events: [NotatedEvent] = [
+            .init(base: .note(pitch: Pitch(step: .G, alter: 0, octave: 4), duration: Duration(1,16))),
+            .init(base: .note(pitch: Pitch(step: .A, alter: 0, octave: 4), duration: Duration(1,16))),
+            .init(base: .note(pitch: Pitch(step: .B, alter: 0, octave: 4), duration: Duration(1,16))),
+            .init(base: .note(pitch: Pitch(step: .C, alter: 0, octave: 5), duration: Duration(1,16)))
+        ]
+        let r = SimpleRenderer()
+        var opts = LayoutOptions(); opts.timeSignature = (4,4)
+        let tree = r.layout(events: events, in: CGRect(x: 0, y: 0, width: 400, height: 160), options: opts)
+        XCTAssertEqual(tree.beamGroups.count, 1)
+        XCTAssertEqual(tree.beamGroups[0], [0,1,2,3])
+        // beamLevels should indicate at least 2 between adjacent notes
+        let level01 = min(tree.beamLevels[0], tree.beamLevels[1])
+        let level12 = min(tree.beamLevels[1], tree.beamLevels[2])
+        XCTAssertGreaterThanOrEqual(level01, 2)
+        XCTAssertGreaterThanOrEqual(level12, 2)
+    }
+}
+


### PR DESCRIPTION
- LayoutTree exposes beamGroups and beamLevels; beat-aware grouping\n- UI tests validate eighths group per beat and 16th multi-level beams\n- Adds ScoreKitBench exec to time layouts for common densities\n\nAll tests passing.