### PR TITLE
AudioTalk Preview: Session API + Demo + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,25 @@ Roadmap
   - Edits are snappy: the renderer only re‑lays out affected measures and shifts what follows, so most changes feel immediate.
   - A tiny playback path converts notes to MIDI 2.0 UMP messages so you can wire them to a device or print them for debugging; basic playhead following is included.
   - A LilyPond wrapper can emit `.ly` and, if LilyPond is installed, produce PDF/SVG for high‑quality output (tests default to a no‑exec mode).
-  - A small LilyPond import subset can read back simple snippets and round‑trip core markings.
+- A small LilyPond import subset can read back simple snippets and round‑trip core markings.
 - What this is not (yet): a full notation editor or DAW replacement. It’s a focused toolkit for coaching, annotation, playback hooks, and fast UI feedback.
+
+AudioTalk Preview (Core Flow)
+- ScoreKit previews what AI (AudioTalk/FountainAI) changes in your score.
+- The AI sends structured ops (slur, hairpin, articulation, dynamic). ScoreKit applies them and reflows just what’s needed.
+- Use `AudioTalkPreviewSession` to apply ops and get changed indices for highlighting and incremental layout. The demo includes a “Run AI Preview” action.
+
+Example
+```
+let session = AudioTalkPreviewSession(events: events)
+let ops: [PatchOp] = [
+  .hairpin(start: 0, end: events.count - 1, type: .crescendo),
+  .slur(start: 4, end: 7),
+  .dynamic(index: 0, level: .mp)
+]
+let (updated, changed) = session.apply(ops: ops)
+// Pass 'updated' to ScoreView; use 'changed' for updateLayout + highlight
+```
 
 Try It
 - Demo app (macOS): `cd ScoreKit && swift run ScoreKitDemo`

--- a/Sources/ScoreKitUI/Interaction/AudioTalkPreview.swift
+++ b/Sources/ScoreKitUI/Interaction/AudioTalkPreview.swift
@@ -1,0 +1,40 @@
+import Foundation
+import ScoreKit
+
+/// Lightweight session to apply AI-generated PatchOps to events
+/// and report changed indices for incremental reflow + highlight.
+@MainActor
+public final class AudioTalkPreviewSession {
+    public private(set) var events: [NotatedEvent]
+
+    public init(events: [NotatedEvent]) { self.events = events }
+
+    /// Apply a batch of PatchOps and return (newEvents, changedIndices)
+    public func apply(ops: [PatchOp]) -> ([NotatedEvent], Set<Int>) {
+        var changed: Set<Int> = []
+        var voice = Voice(events: events)
+        for op in ops {
+            switch op {
+            case .slur(let s, let e):
+                let (nv, _) = Transform.addSlur(to: voice, start: s, end: e)
+                voice = nv
+                changed.formUnion([s, e])
+            case .hairpin(let s, let e, let t):
+                let (nv, _) = Transform.applyHairpin(to: voice, start: s, end: e, type: t)
+                voice = nv
+                changed.formUnion(Set(s...e))
+            case .articulation(let i, let a):
+                let (nv, _) = Transform.addArticulation(to: voice, index: i, articulation: a)
+                voice = nv
+                changed.insert(i)
+            case .dynamic(let i, let lvl):
+                let (nv, _) = Transform.setDynamic(to: voice, index: i, level: lvl)
+                voice = nv
+                changed.insert(i)
+            }
+        }
+        events = voice.events
+        return (events, changed)
+    }
+}
+


### PR DESCRIPTION
Add a lightweight AI preview path:\n- AudioTalkPreviewSession applies PatchOps to events and returns changed indices\n- Demo includes 'Run AI Preview' to simulate AI-generated changes\n- README documents core AI preview flow with code sample\n\nThis focuses the toolkit on ‘seeing what the AI does’ rather than manual editing.